### PR TITLE
Pantalla del home zona blanca lateral

### DIFF
--- a/src/components/Home/Sponsors.css
+++ b/src/components/Home/Sponsors.css
@@ -210,7 +210,7 @@ img {
     height: auto;
     width: 100%;
     overflow: hidden;
-    scale: 1.6;
+    scale: 1.55;
     flex-wrap: wrap;
   }
 


### PR DESCRIPTION
+ El espai en blanc era causat per la scale en la versio movil per a fer els logos de partners més grans. Reduit 0.05 per a que estigui ben ajustat