### PR TITLE
Update Sponsors.js

### DIFF
--- a/src/components/hackeps/Home/Sponsors.js
+++ b/src/components/hackeps/Home/Sponsors.js
@@ -36,32 +36,55 @@ const Sponsors = () => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const event = localStorage.getItem("event");
-    async function fetchData() {
-      if (!event) {
-        setLoading(false);
-        return;
-      }
+  const event = localStorage.getItem("event");
+  
+  async function fetchData() {
+    if (!event) {
+      setLoading(false);
+      return;
+    }
 
+    setLoading(true);
+
+    // Intentaremos un máximo de 2 veces (Intento 1 y un Reintento)
+    for (let attempt = 1; attempt <= 2; attempt++) {
       try {
-        setLoading(true);
+        // 1. OBTENCIÓN DE DATOS COMPLETA
         const challengerData = await getCompanyByTier(2);
-        const sponsorsData = [
-          await getCompanyByTier(1),
-          await getCompanyByTier(3),
-        ];
+        const [tier1, tier3] = await Promise.all([
+          getCompanyByTier(1),
+          getCompanyByTier(3),
+        ]);
+        const sponsorsData = [tier1, tier3];
 
+        // 2. COMPROBACIÓN
+        const dataIsEmpty = challengerData.length === 0 || sponsorsData.every(group => group.length === 0);
+
+        if (dataIsEmpty && attempt < 2) {
+          console.warn(`Intento ${attempt} fallido. Reintentando...`);
+
+          continue; 
+        }
+
+        // 3. ACTUALIZACIÓN DE ESTADO Y SALIDA
         setChallenger(challengerData || []);
         setSponsors(sponsorsData || []);
-      } catch (error) {
-        console.error("Error fetching sponsors data:", error);
-        setChallenger([]);
-        setSponsors([]);
-      } finally {
+        
+        if (dataIsEmpty && attempt === 2) {
+          console.error("Los datos siguen vacíos tras el último reintento.");
+        }
+        
         setLoading(false);
+        return; 
+
+      } catch (error) {
+        console.error("Error fetching data:", error);
+        break; 
       }
     }
-    fetchData();
+    setLoading(false);
+  }
+  fetchData();
   }, []);
 
   return (


### PR DESCRIPTION
This pull request improves the sponsor data fetching logic in the `Sponsors` component to make it more robust against empty or failed responses. The main enhancement is the introduction of a retry mechanism, which attempts to fetch data up to two times before giving up. This helps ensure that temporary issues or incomplete data do not immediately result in an empty state for the sponsors list.

**Data fetching reliability improvements:**

* Added a retry mechanism in the `fetchData` function to attempt data fetching up to two times if the initial response is empty, increasing robustness against transient failures.
* Improved sponsor data fetching by using `Promise.all` for parallel requests and validating the completeness of the returned data before updating the state.
* Enhanced error handling and logging to provide clearer feedback when data remains empty after retries or if an exception occurs during fetching.Now would make a second try if data is empty