### PR TITLE
Add QuiSom landing page and team components

### DIFF
--- a/src/components/hackeps/Home/MainTitle.js
+++ b/src/components/hackeps/Home/MainTitle.js
@@ -13,7 +13,6 @@ const MainTitle = ({ buttonText = "Apunta't!", refresh = false }) => {
   const handleClose = () => setShow(false);
 
   async function handleShow() {
-
     if (hackDay) {
       window.location.href = "https://live.lleidahack.dev";
       return;
@@ -106,13 +105,9 @@ const MainTitle = ({ buttonText = "Apunta't!", refresh = false }) => {
                 backgroundPosition: "center",
                 backgroundRepeat: "no-repeat",
                 scale: "1.7",
-
               }}
             >
-              <p className="px-4 mt-3 py-3">
-                {textButton}
-
-              </p>
+              <p className="px-4 mt-3 py-3">{textButton}</p>
             </div>
           </Button>
         </div>

--- a/src/components/landing/ImageCards/MemberCard.js
+++ b/src/components/landing/ImageCards/MemberCard.js
@@ -1,10 +1,11 @@
-import React from 'react';
-import { FaGithub, FaLinkedin } from 'react-icons/fa';
+import React from "react";
+import { FaGithub, FaLinkedin } from "react-icons/fa";
 
 const MemberCard = ({ name, role, bgColor, github, linkedin, photo }) => {
   return (
-    <div className={`${bgColor} py-10 px-8 rounded-xl flex flex-col items-center text-center shadow-md font-mono h-full w-full max-w-[350px] mx-auto transition-all duration-300 hover:shadow-xl`}>
-      
+    <div
+      className={`${bgColor} py-10 px-8 rounded-xl flex flex-col items-center text-center shadow-md font-mono h-full w-full max-w-[350px] mx-auto transition-all duration-300 hover:shadow-xl`}
+    >
       <div className="w-44 h-44 bg-white rounded-full mb-6 overflow-hidden shadow-md flex items-center justify-center border-4 border-white/30">
         {photo ? (
           <img src={photo} alt={name} className="w-full h-full object-cover" />
@@ -12,19 +13,31 @@ const MemberCard = ({ name, role, bgColor, github, linkedin, photo }) => {
           <div className="w-full h-full bg-gray-100" />
         )}
       </div>
-      
+
       <div className="flex-grow flex flex-col justify-center">
         <h3 className="font-bold text-2xl leading-tight mb-3 uppercase tracking-tighter">
           {name}
         </h3>
-        <p className="text-base mb-6 text-gray-800 uppercase font-black opacity-90 tracking-wide">{role}</p>
+        <p className="text-base mb-6 text-gray-800 uppercase font-black opacity-90 tracking-wide">
+          {role}
+        </p>
       </div>
-      
+
       <div className="flex gap-6 mt-auto pt-2">
-        <a href={github} target="_blank" rel="noopener noreferrer" className="hover:scale-125 transition-transform text-black">
+        <a
+          href={github}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:scale-125 transition-transform text-black"
+        >
           <FaGithub size={32} />
         </a>
-        <a href={linkedin} target="_blank" rel="noopener noreferrer" className="hover:scale-125 transition-transform text-black">
+        <a
+          href={linkedin}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:scale-125 transition-transform text-black"
+        >
           <FaLinkedin size={32} />
         </a>
       </div>

--- a/src/components/landing/ImageCards/MemberCard.js
+++ b/src/components/landing/ImageCards/MemberCard.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { FaGithub, FaLinkedin } from 'react-icons/fa';
+
+const MemberCard = ({ name, role, bgColor, github, linkedin, photo }) => {
+  return (
+    <div className={`${bgColor} py-10 px-8 rounded-xl flex flex-col items-center text-center shadow-md font-mono h-full w-full max-w-[350px] mx-auto transition-all duration-300 hover:shadow-xl`}>
+      
+      <div className="w-44 h-44 bg-white rounded-full mb-6 overflow-hidden shadow-md flex items-center justify-center border-4 border-white/30">
+        {photo ? (
+          <img src={photo} alt={name} className="w-full h-full object-cover" />
+        ) : (
+          <div className="w-full h-full bg-gray-100" />
+        )}
+      </div>
+      
+      <div className="flex-grow flex flex-col justify-center">
+        <h3 className="font-bold text-2xl leading-tight mb-3 uppercase tracking-tighter">
+          {name}
+        </h3>
+        <p className="text-base mb-6 text-gray-800 uppercase font-black opacity-90 tracking-wide">{role}</p>
+      </div>
+      
+      <div className="flex gap-6 mt-auto pt-2">
+        <a href={github} target="_blank" rel="noopener noreferrer" className="hover:scale-125 transition-transform text-black">
+          <FaGithub size={32} />
+        </a>
+        <a href={linkedin} target="_blank" rel="noopener noreferrer" className="hover:scale-125 transition-transform text-black">
+          <FaLinkedin size={32} />
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default MemberCard;

--- a/src/components/landing/QuiSom/IntroSection.js
+++ b/src/components/landing/QuiSom/IntroSection.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const IntroSection = () => {
+  const introData = [
+    { title: "Volem aprendre", img: "https://estaticos-cdn.prensaiberica.es/clip/255b7d28-259a-41c4-91b4-02699cc3fc59_16-9-aspect-ratio_default_0.jpg", text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut elit tellus, luctus nec ullamcorper mattis, pulvinar dapibus leo." },
+    { title: "Activitats", img: "https://estaticos-cdn.prensaiberica.es/clip/255b7d28-259a-41c4-91b4-02699cc3fc59_16-9-aspect-ratio_default_0.jpg", text: "Mauris in erat justo. Nullam ac urna eu felis dapibus condimentum sit amet a augue." },
+    { title: "Esdeveniments", img: "https://estaticos-cdn.prensaiberica.es/clip/255b7d28-259a-41c4-91b4-02699cc3fc59_16-9-aspect-ratio_default_0.jpg", text: "Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos." }
+  ];
+
+  return (
+    <section className="mx-36 flex flex-col gap-24 mt-10">
+      {introData.map((item, index) => (
+        <div key={index} className="flex flex-col gap-6">
+          <img src={item.img} alt={item.title} className="w-full h-auto object-cover rounded-sm shadow-sm" />
+          
+          <h2 className="font-mono font-black text-5xl uppercase tracking-tighter">{item.title}</h2>
+          
+          <p className="font-mono text-base text-justify tracking-tight">{item.text}</p>
+        </div>
+      ))}
+    </section>
+  );
+};
+
+export default IntroSection;

--- a/src/components/landing/QuiSom/IntroSection.js
+++ b/src/components/landing/QuiSom/IntroSection.js
@@ -1,21 +1,41 @@
-import React from 'react';
+import React from "react";
 
 const IntroSection = () => {
   const introData = [
-    { title: "Volem aprendre", img: "https://estaticos-cdn.prensaiberica.es/clip/255b7d28-259a-41c4-91b4-02699cc3fc59_16-9-aspect-ratio_default_0.jpg", text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut elit tellus, luctus nec ullamcorper mattis, pulvinar dapibus leo." },
-    { title: "Activitats", img: "https://estaticos-cdn.prensaiberica.es/clip/255b7d28-259a-41c4-91b4-02699cc3fc59_16-9-aspect-ratio_default_0.jpg", text: "Mauris in erat justo. Nullam ac urna eu felis dapibus condimentum sit amet a augue." },
-    { title: "Esdeveniments", img: "https://estaticos-cdn.prensaiberica.es/clip/255b7d28-259a-41c4-91b4-02699cc3fc59_16-9-aspect-ratio_default_0.jpg", text: "Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos." }
+    {
+      title: "Volem aprendre",
+      img: "https://estaticos-cdn.prensaiberica.es/clip/255b7d28-259a-41c4-91b4-02699cc3fc59_16-9-aspect-ratio_default_0.jpg",
+      text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut elit tellus, luctus nec ullamcorper mattis, pulvinar dapibus leo.",
+    },
+    {
+      title: "Activitats",
+      img: "https://estaticos-cdn.prensaiberica.es/clip/255b7d28-259a-41c4-91b4-02699cc3fc59_16-9-aspect-ratio_default_0.jpg",
+      text: "Mauris in erat justo. Nullam ac urna eu felis dapibus condimentum sit amet a augue.",
+    },
+    {
+      title: "Esdeveniments",
+      img: "https://estaticos-cdn.prensaiberica.es/clip/255b7d28-259a-41c4-91b4-02699cc3fc59_16-9-aspect-ratio_default_0.jpg",
+      text: "Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.",
+    },
   ];
 
   return (
     <section className="mx-36 flex flex-col gap-24 mt-10">
       {introData.map((item, index) => (
         <div key={index} className="flex flex-col gap-6">
-          <img src={item.img} alt={item.title} className="w-full h-auto object-cover rounded-sm shadow-sm" />
-          
-          <h2 className="font-mono font-black text-5xl uppercase tracking-tighter">{item.title}</h2>
-          
-          <p className="font-mono text-base text-justify tracking-tight">{item.text}</p>
+          <img
+            src={item.img}
+            alt={item.title}
+            className="w-full h-auto object-cover rounded-sm shadow-sm"
+          />
+
+          <h2 className="font-mono font-black text-5xl uppercase tracking-tighter">
+            {item.title}
+          </h2>
+
+          <p className="font-mono text-base text-justify tracking-tight">
+            {item.text}
+          </p>
         </div>
       ))}
     </section>

--- a/src/components/landing/QuiSom/TeamSection.js
+++ b/src/components/landing/QuiSom/TeamSection.js
@@ -1,36 +1,96 @@
-import React from 'react';
-import MemberCard from 'src/components/landing/ImageCards/MemberCard';
+import React from "react";
+import MemberCard from "src/components/landing/ImageCards/MemberCard";
 
 const TeamSection = () => {
   const teamData = {
     junta: [
-      { 
-        name: "Pol Llinàs", 
-        role: "President", 
-        github: "https://github.com", 
+      {
+        name: "Pol Llinàs",
+        role: "President",
+        github: "https://github.com",
         linkedin: "https://www.linkedin.com/in/pol-llinas-vaquer/",
-        photo: "https://media.licdn.com/dms/image/v2/D5603AQEt3ZMvju9FhQ/profile-displayphoto-shrink_800_800/profile-displayphoto-shrink_800_800/0/1728896614919?e=1772064000&v=beta&t=NRAd4m3U9pctJkS0XnkEh53tq0y8rAlTCeawPnJmfHY" 
+        photo:
+          "https://media.licdn.com/dms/image/v2/D5603AQEt3ZMvju9FhQ/profile-displayphoto-shrink_800_800/profile-displayphoto-shrink_800_800/0/1728896614919?e=1772064000&v=beta&t=NRAd4m3U9pctJkS0XnkEh53tq0y8rAlTCeawPnJmfHY",
       },
-      { name: "Naïm Saadi Gallego", role: "Secretari", github: "#", linkedin: "#", photo: "" },
-      { name: "Arnau Vernet Grifoll", role: "Tresorer", github: "#", linkedin: "#", photo: "" },
+      {
+        name: "Naïm Saadi Gallego",
+        role: "Secretari",
+        github: "#",
+        linkedin: "#",
+        photo: "",
+      },
+      {
+        name: "Arnau Vernet Grifoll",
+        role: "Tresorer",
+        github: "#",
+        linkedin: "#",
+        photo: "",
+      },
     ],
     caps: [
-      { name: "Enric Eroles", role: "Cap de Logística", github: "#", linkedin: "#", photo: "" },
-      { name: "Miriam Rodríguez", role: "Cap de Marketing", github: "#", linkedin: "#", photo: "" },
-      { name: "Joel Ros Peropadre", role: "Cap de Tecnologia", github: "#", linkedin: "#", photo: "" },
-      { name: "Oriol Agost Batalla", role: "Cap de Patrocini", github: "#", linkedin: "#", photo: "" },
-      { name: "Ferran López Sierra", role: "Cap de Webmaster", github: "#", linkedin: "#", photo: "" },
+      {
+        name: "Enric Eroles",
+        role: "Cap de Logística",
+        github: "#",
+        linkedin: "#",
+        photo: "",
+      },
+      {
+        name: "Miriam Rodríguez",
+        role: "Cap de Marketing",
+        github: "#",
+        linkedin: "#",
+        photo: "",
+      },
+      {
+        name: "Joel Ros Peropadre",
+        role: "Cap de Tecnologia",
+        github: "#",
+        linkedin: "#",
+        photo: "",
+      },
+      {
+        name: "Oriol Agost Batalla",
+        role: "Cap de Patrocini",
+        github: "#",
+        linkedin: "#",
+        photo: "",
+      },
+      {
+        name: "Ferran López Sierra",
+        role: "Cap de Webmaster",
+        github: "#",
+        linkedin: "#",
+        photo: "",
+      },
     ],
     membres: [
-      { name: "Nataly Jaya Salazar", role: "Membre de Marketing", github: "#", linkedin: "#", photo: "" },
-      { name: "Nataly Jaya Salazar", role: "Membre de Marketing", github: "#", linkedin: "#", photo: "" },
-      { name: "Nataly Jaya Salazar", role: "Membre de Marketing", github: "#", linkedin: "#", photo: "" },
-    ]
+      {
+        name: "Nataly Jaya Salazar",
+        role: "Membre de Marketing",
+        github: "#",
+        linkedin: "#",
+        photo: "",
+      },
+      {
+        name: "Nataly Jaya Salazar",
+        role: "Membre de Marketing",
+        github: "#",
+        linkedin: "#",
+        photo: "",
+      },
+      {
+        name: "Nataly Jaya Salazar",
+        role: "Membre de Marketing",
+        github: "#",
+        linkedin: "#",
+        photo: "",
+      },
+    ],
   };
 
   return (
-    <div className="flex flex-col gap-20"> 
-      
+    <div className="flex flex-col gap-20">
       {/* 1. LÍNIA TARONJA DE SEPARACIÓ */}
       <div className="flex justify-center mt-10">
         <div className="h-1.5 w-1/2 bg-orange-500 rounded-full"></div>
@@ -38,7 +98,9 @@ const TeamSection = () => {
 
       {/* SECCIÓ JUNTA */}
       <section className="mx-36">
-        <h2 className="text-7xl font-mono font-black text-center mb-24 tracking-tighter uppercase">Junta</h2>
+        <h2 className="text-7xl font-mono font-black text-center mb-24 tracking-tighter uppercase">
+          Junta
+        </h2>
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-12">
           {teamData.junta.map((m, i) => (
             <MemberCard key={i} {...m} bgColor="bg-orange-500" />
@@ -48,7 +110,9 @@ const TeamSection = () => {
 
       {/* SECCIÓ CAPS D'EQUIP */}
       <section className="mx-36">
-        <h2 className="text-7xl font-mono font-black text-center mb-24 tracking-tighter uppercase">Caps d'Equip</h2>
+        <h2 className="text-7xl font-mono font-black text-center mb-24 tracking-tighter uppercase">
+          Caps d'Equip
+        </h2>
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-12 mb-12">
           {teamData.caps.slice(0, 3).map((m, i) => (
             <MemberCard key={i} {...m} bgColor="bg-[#FFD1B9]" />
@@ -63,7 +127,9 @@ const TeamSection = () => {
 
       {/* SECCIÓ MEMBRES */}
       <section className="mx-36 relative pt-12 pb-32">
-        <h2 className="text-7xl font-mono font-black text-center mb-24 tracking-tighter uppercase">Membres</h2>
+        <h2 className="text-7xl font-mono font-black text-center mb-24 tracking-tighter uppercase">
+          Membres
+        </h2>
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-10">
           {teamData.membres.map((m, i) => (
             <MemberCard key={i} {...m} bgColor="bg-gray-400" />

--- a/src/components/landing/QuiSom/TeamSection.js
+++ b/src/components/landing/QuiSom/TeamSection.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import MemberCard from 'src/components/landing/ImageCards/MemberCard';
+
+const TeamSection = () => {
+  const teamData = {
+    junta: [
+      { 
+        name: "Pol Llinàs", 
+        role: "President", 
+        github: "https://github.com", 
+        linkedin: "https://www.linkedin.com/in/pol-llinas-vaquer/",
+        photo: "https://media.licdn.com/dms/image/v2/D5603AQEt3ZMvju9FhQ/profile-displayphoto-shrink_800_800/profile-displayphoto-shrink_800_800/0/1728896614919?e=1772064000&v=beta&t=NRAd4m3U9pctJkS0XnkEh53tq0y8rAlTCeawPnJmfHY" 
+      },
+      { name: "Naïm Saadi Gallego", role: "Secretari", github: "#", linkedin: "#", photo: "" },
+      { name: "Arnau Vernet Grifoll", role: "Tresorer", github: "#", linkedin: "#", photo: "" },
+    ],
+    caps: [
+      { name: "Enric Eroles", role: "Cap de Logística", github: "#", linkedin: "#", photo: "" },
+      { name: "Miriam Rodríguez", role: "Cap de Marketing", github: "#", linkedin: "#", photo: "" },
+      { name: "Joel Ros Peropadre", role: "Cap de Tecnologia", github: "#", linkedin: "#", photo: "" },
+      { name: "Oriol Agost Batalla", role: "Cap de Patrocini", github: "#", linkedin: "#", photo: "" },
+      { name: "Ferran López Sierra", role: "Cap de Webmaster", github: "#", linkedin: "#", photo: "" },
+    ],
+    membres: [
+      { name: "Nataly Jaya Salazar", role: "Membre de Marketing", github: "#", linkedin: "#", photo: "" },
+      { name: "Nataly Jaya Salazar", role: "Membre de Marketing", github: "#", linkedin: "#", photo: "" },
+      { name: "Nataly Jaya Salazar", role: "Membre de Marketing", github: "#", linkedin: "#", photo: "" },
+    ]
+  };
+
+  return (
+    <div className="flex flex-col gap-20"> 
+      
+      {/* 1. LÍNIA TARONJA DE SEPARACIÓ */}
+      <div className="flex justify-center mt-10">
+        <div className="h-1.5 w-1/2 bg-orange-500 rounded-full"></div>
+      </div>
+
+      {/* SECCIÓ JUNTA */}
+      <section className="mx-36">
+        <h2 className="text-7xl font-mono font-black text-center mb-24 tracking-tighter uppercase">Junta</h2>
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-12">
+          {teamData.junta.map((m, i) => (
+            <MemberCard key={i} {...m} bgColor="bg-orange-500" />
+          ))}
+        </div>
+      </section>
+
+      {/* SECCIÓ CAPS D'EQUIP */}
+      <section className="mx-36">
+        <h2 className="text-7xl font-mono font-black text-center mb-24 tracking-tighter uppercase">Caps d'Equip</h2>
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-12 mb-12">
+          {teamData.caps.slice(0, 3).map((m, i) => (
+            <MemberCard key={i} {...m} bgColor="bg-[#FFD1B9]" />
+          ))}
+        </div>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 max-w-5xl mx-auto">
+          {teamData.caps.slice(3).map((m, i) => (
+            <MemberCard key={i} {...m} bgColor="bg-[#FFD1B9]" />
+          ))}
+        </div>
+      </section>
+
+      {/* SECCIÓ MEMBRES */}
+      <section className="mx-36 relative pt-12 pb-32">
+        <h2 className="text-7xl font-mono font-black text-center mb-24 tracking-tighter uppercase">Membres</h2>
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-10">
+          {teamData.membres.map((m, i) => (
+            <MemberCard key={i} {...m} bgColor="bg-gray-400" />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default TeamSection;

--- a/src/pages/Landing/QuiSomLanding.js
+++ b/src/pages/Landing/QuiSomLanding.js
@@ -1,0 +1,16 @@
+import Navbar from "src/components/landing/Navbar/Navbar";
+import Footer from "src/components/landing/Footer/Footer";
+import IntroSection from "src/components/landing/QuiSom/IntroSection";
+import TeamSection from "src/components/landing/QuiSom/TeamSection";
+
+const QuiSomLanding = () => {
+  return (
+    <div>
+      <Navbar />
+      <IntroSection />
+      <TeamSection />
+      <Footer />
+    </div>
+  );
+};
+export default QuiSomLanding;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -59,7 +59,7 @@ module.exports = {
       "background-cartellB": "url('/src/assets/Cartell B.png')",
       "background-cartellC": "url('/src/assets/Cartell C.png')",
       "background-cartellD": "url('/src/assets/Cartell D.png')",
-      'background-garabato': "url('/src/assets/img/garabato.png')",
+      "background-garabato": "url('/src/assets/img/garabato.png')",
     },
   },
   plugins: [],


### PR DESCRIPTION
Introduce a new QuiSom landing page and supporting components: MemberCard (profile card with photo and GitHub/LinkedIn icons and Tailwind styling), IntroSection (three intro items with images and text), and TeamSection (renders Junta, Caps, and Membres grids using sample data and color variants). Add QuiSomLanding page that composes Navbar, IntroSection, TeamSection and Footer. Placeholder images/links are included for initial layout.